### PR TITLE
This commit removes "blobs" to fix build errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,3 @@
 	url = https://review.coreboot.org/amd_blobs
 	update = none
 	ignore = dirty
-[submodule "private/blobs"]
-    	path = blobs
-	url =
-    	ignore = all


### PR DESCRIPTION
There were build errors related to not being able to pull down the
proper submodules due to no "url" being specified for the "blobs" git
module.  This commit fixes the git submodule error and subsequently
the build issue.

Don't feel obligated to merge this, I just noticed it while doing some work and thought I would create a PR fixing the issue. Likewise if you would like me to re-target a different branch just let me know.