### PR TITLE
Test for existance of destination directory before copy.

### DIFF
--- a/build-uefi.sh
+++ b/build-uefi.sh
@@ -36,6 +36,9 @@ for device in "${build_targets[@]}"; do
 	echo -e "\t\t\"url\": \"${rom_path}${filename}\"," >> $json_file
 	echo -e "\t\t\"sha1\": \"$(cat ${filename}.sha1 | awk 'NR==1{print $1}')\"" >> $json_file
 	echo -e "\t}," >> $json_file
-	mv ${filename}* ~/dev/firmware/
+	if [ -d ~/dev/firmware/ ]
+	then
+		mv ${filename}* ~/dev/firmware/
+	fi
 done
 echo -e "}" >> $json_file


### PR DESCRIPTION
 To prevent script from crashing prematurely.

You know, for everyone else who's not dedicated enough to have a dev/firmware in the home directory who is not the primary maintainer. :D