### PR TITLE
build-uefi.sh: Use path agnostic bash location

### DIFF
--- a/build-uefi.sh
+++ b/build-uefi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 
 set -e


### PR DESCRIPTION
Hardcoding the path may fail on some weird distros like NixOS (which I'm using). This patch makes use of the env utility which should be present on all distros at the /usr/bin/env path :)