### PR TITLE
build-uefi.sh: Clarify the usage instructions

### DIFF
--- a/build-uefi.sh
+++ b/build-uefi.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+
+# USAGE: ./build-uefi.sh {device}
 #
+# NOTE: In order to use this script, please make sure you have the neccessary binary blobs
+# 	in their correspondent location inside the 3rdparty/blobs/ directory.
 
 set -e
 


### PR DESCRIPTION
This patch adds a bit of clarification on how this script should be used and the needed prerequisites for the script to successfully build coreboot.

P.S. I think this would be useful (at least for me) as it would've saved me quite a lot of time of me banging my head against the wall :))