### PR TITLE
mb/google/brya/var/taeko: enable both eMMC and NVMe drives

### DIFF
--- a/src/mainboard/google/brya/variants/taeko/overridetree.cb
+++ b/src/mainboard/google/brya/variants/taeko/overridetree.cb
@@ -376,7 +376,6 @@ chip soc/intel/alderlake
 				.clk_src = 0,
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 			}"
-			probe BOOT_NVME_MASK BOOT_NVME_ENABLED
 		end
 		device ref tbt_pcie_rp0 off end
 		device ref tbt_pcie_rp1 off end
@@ -542,7 +541,6 @@ chip soc/intel/alderlake
 				.flags = PCIE_RP_LTR | PCIE_RP_AER,
 				.pcie_rp_aspm = ASPM_L1,
 			}"
-			probe BOOT_EMMC_MASK BOOT_EMMC_ENABLED
 		end
 		device ref gspi1 on
 			chip drivers/spi/acpi


### PR DESCRIPTION
Ignore FW_CONFIG setting and detect which is present - same as 'taniks' variant.