### PR TITLE
mb/google/hatch/kohaku: Raise PL1 to 12W

### DIFF
--- a/src/mainboard/google/hatch/variants/kohaku/overridetree.cb
+++ b/src/mainboard/google/hatch/variants/kohaku/overridetree.cb
@@ -1,6 +1,6 @@
 chip soc/intel/cannonlake
 	register "power_limits_config" = "{
-		.tdp_pl1_override = 8,
+		.tdp_pl1_override = 12,
 		.tdp_pl2_override = 51,
 	}"
 


### PR DESCRIPTION
Kohaku is unusable with stock Power Limit under AltOS.
According to our thermal testing, this is the maximum safe value for fanless i5-10210U.