### PR TITLE
Disable legacy timers on volteer and brya

### DIFF
--- a/src/mainboard/google/brya/Kconfig
+++ b/src/mainboard/google/brya/Kconfig
@@ -753,6 +753,9 @@ config USE_PM_ACPI_TIMER
 	default y if BOARD_GOOGLE_PRIMUS4ES
 	default n
 
+config USE_LEGACY_8254_TIMER
+        default n
+
 config DEFAULT_ADL_NEM
 	bool
 	help

--- a/src/mainboard/google/volteer/Kconfig
+++ b/src/mainboard/google/volteer/Kconfig
@@ -178,6 +178,12 @@ config DRIVER_TPM_I2C_ADDR
 	hex
 	default 0x50
 
+config USE_PM_ACPI_TIMER
+        default n
+
+config USE_LEGACY_8254_TIMER
+	default n
+
 config INTEL_GMA_VBT_FILE
 	default "src/mainboard/\$(MAINBOARDDIR)/variants/\$(VARIANT_DIR)/data.vbt" \
 		if BOARD_GOOGLE_ELEMI || BOARD_GOOGLE_LINDAR || \


### PR DESCRIPTION
As stated in commits, enabling PM and 8254 timers (which coreboot does automatically) breaks s0ix state on those boards.
Since they've never been verified for S3, we need to ensure coreboot doesn't enable them to have functional sleep state.

I tested it on ELDRID, CoolStar tested it on BANSHEE.