### PR TITLE
HACK: Atlas disable camera ACPI for Windows

### DIFF
--- a/src/mainboard/google/poppy/variants/atlas/include/variant/acpi/camera.asl
+++ b/src/mainboard/google/poppy/variants/atlas/include/variant/acpi/camera.asl
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-#include "ipu_mainboard.asl"
-#include "ipu_endpoints.asl"
-#include "cam0.asl"
+//#include "ipu_mainboard.asl"
+//#include "ipu_endpoints.asl"
+//#include "cam0.asl"


### PR DESCRIPTION
The webcam is non-functional under both Windows and Linux, this change keeps the green camera LED off under windows, and brings atlas in line with nocturne.   

https://github.com/MrChromebox/firmware/issues/362

https://github.com/MrChromebox/coreboot/commit/63ff84501a64a79f4cf9aa6068ed5b04c2bf6f5e

https://forum.chrultrabook.com/t/pixelbook-go-webcam-led-always-on/