### PR TITLE
Redrix disable camera LED for Windows

### DIFF
--- a/src/mainboard/google/brya/variants/redrix/overridetree.cb
+++ b/src/mainboard/google/brya/variants/redrix/overridetree.cb
@@ -366,21 +366,16 @@ chip soc/intel/alderlake
 				register "clk_panel.clks[0].clknum" = "IMGCLKOUT_3"
 				register "clk_panel.clks[0].freq" = "FREQ_19_2_MHZ"
 
-				register "gpio_panel.gpio[0].gpio_num" = "GPP_D15"  #EN_UCAM_LED_PWR
+				#register "gpio_panel.gpio[0].gpio_num" = "GPP_D15"  #EN_UCAM_LED_PWR
 				register "gpio_panel.gpio[1].gpio_num" = "GPP_D3" #reset
 
 				#_ON
-				register "on_seq.ops_cnt" = "4"
+				register "on_seq.ops_cnt" = "1"
 				register "on_seq.ops[0]" = "SEQ_OPS_CLK_ENABLE(0, 0)"
-				register "on_seq.ops[1]" = "SEQ_OPS_GPIO_ENABLE(0, 5)"
-				register "on_seq.ops[2]" = "SEQ_OPS_GPIO_DISABLE(1, 5)"
-				register "on_seq.ops[3]" = "SEQ_OPS_GPIO_ENABLE(1, 5)"
 
 				#_OFF
-				register "off_seq.ops_cnt" = "3"
+				register "off_seq.ops_cnt" = "1"
 				register "off_seq.ops[0]" = "SEQ_OPS_CLK_DISABLE(0, 0)"
-				register "off_seq.ops[1]" = "SEQ_OPS_GPIO_DISABLE(1, 0)"
-				register "off_seq.ops[2]" = "SEQ_OPS_GPIO_DISABLE(0, 0)"
 				device i2c 36 on
 					probe CAMERA_UFC CAMERA_NONE
 					probe CAMERA_UFC CAMERA_OV5675
@@ -405,21 +400,16 @@ chip soc/intel/alderlake
 				register "clk_panel.clks[0].clknum" = "IMGCLKOUT_3"
 				register "clk_panel.clks[0].freq" = "FREQ_19_2_MHZ"
 
-				register "gpio_panel.gpio[0].gpio_num" = "GPP_D15"  #EN_UCAM_LED_PWR
+				#register "gpio_panel.gpio[0].gpio_num" = "GPP_D15"  #EN_UCAM_LED_PWR
 				register "gpio_panel.gpio[1].gpio_num" = "GPP_D3" #reset
 
 				#_ON
-				register "on_seq.ops_cnt" = "4"
+				register "on_seq.ops_cnt" = "1"
 				register "on_seq.ops[0]" = "SEQ_OPS_CLK_ENABLE(0, 0)"
-				register "on_seq.ops[1]" = "SEQ_OPS_GPIO_ENABLE(0, 5)"
-				register "on_seq.ops[2]" = "SEQ_OPS_GPIO_DISABLE(1, 5)"
-				register "on_seq.ops[3]" = "SEQ_OPS_GPIO_ENABLE(1, 5)"
 
 				#_OFF
-				register "off_seq.ops_cnt" = "3"
+				register "off_seq.ops_cnt" = "1"
 				register "off_seq.ops[0]" = "SEQ_OPS_CLK_DISABLE(0, 0)"
-				register "off_seq.ops[1]" = "SEQ_OPS_GPIO_DISABLE(1, 0)"
-				register "off_seq.ops[2]" = "SEQ_OPS_GPIO_DISABLE(0, 0)"
 				device i2c 20 on
 					probe CAMERA_UFC CAMERA_HI556
 				end


### PR DESCRIPTION
The webcam is non-functional under both Windows and Linux, this change keeps the white camera LED off under Windows, otherwise the LED will always keep on.