### PR TITLE
Modify the kohaku wacom device id

### DIFF
--- a/src/mainboard/google/hatch/variants/kohaku/overridetree.cb
+++ b/src/mainboard/google/hatch/variants/kohaku/overridetree.cb
@@ -165,7 +165,7 @@ chip soc/intel/cannonlake
 		end # I2C #1
 		device ref i2c2		on
 			chip drivers/i2c/hid
-				register "generic.hid" = ""WCOM50C1""
+				register "generic.hid" = ""WCOM006C""
 				register "generic.desc" = ""WCOM Digitizer""
 				register "generic.irq" = "ACPI_IRQ_LEVEL_LOW(GPP_C7_IRQ)"
 				register "generic.enable_gpio" = "ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_C15)"


### PR DESCRIPTION
Modify the device id of kohaku's wacom digitizer to support the pen driver of Samsung book.
The driver maps other spen side keys to erasers and supports air command(though the pen that comes with the device does not have a button 😂)

The following is a list of devices with the pens2helper driver for the Samsung windows platform
I think at least for the wacom emr2.0 digitizer devices after 2017, they are all universal.
You may consider using the following device ID for other Chromebooks equipped with wacom emr technology.

<img width="1246" height="826" alt="wacom" src="https://github.com/user-attachments/assets/31aacdb0-5142-4323-9ec1-ca91c442a846" />

- It works well on kohaku
For driver download, download samsung update from the Microsoft Store, search for the device NP930QCA-KA1HK (WACOM006C is the digitizer ID for this device), and download the pen driver
<img width="458" height="622" alt="spen" src="https://github.com/user-attachments/assets/fab12944-3f1e-4187-92e8-7f730496d0e7" />