### PR TITLE
soc/intel/skylake: Add mainboard fixup function for FSP-S params

### DIFF
--- a/src/soc/intel/skylake/chip.c
+++ b/src/soc/intel/skylake/chip.c
@@ -502,10 +502,18 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	params->PavpEnable = CONFIG(PAVP);
 
 	soc_irq_settings(params);
+
+	mainboard_silicon_init_params_fixup(params);
 }
 
 /* Mainboard FSP Configuration */
 __weak void mainboard_silicon_init_params(FSP_S_CONFIG *params)
+{
+	printk(BIOS_DEBUG, "WEAK: %s/%s called\n", __FILE__, __func__);
+}
+
+/* Mainboard FSP Configuration fixup */
+__weak void mainboard_silicon_init_params_fixup(FSP_S_CONFIG *params)
 {
 	printk(BIOS_DEBUG, "WEAK: %s/%s called\n", __FILE__, __func__);
 }

--- a/src/soc/intel/skylake/include/soc/ramstage.h
+++ b/src/soc/intel/skylake/include/soc/ramstage.h
@@ -13,6 +13,7 @@
 #define FSP_MEM_UPD FSP_M_CONFIG
 
 void mainboard_silicon_init_params(FSP_S_CONFIG *params);
+void mainboard_silicon_init_params_fixup(FSP_S_CONFIG *params);
 void soc_init_pre_device(void *chip_info);
 void soc_irq_settings(FSP_SIL_UPD *params);
 


### PR DESCRIPTION
Coreboot SoC code for FSP-S has a function for mainboard FSP-S params configuration - `mainboard_silicon_init_params()`. Mainboards can utilize this to make their own changes to params prior to FSP-S init, for example to apply CFR or some other board specific changes.

In the case of Skylake/Kabylake this function is called at the beginning of FSP-S callback. In newer generations it is called at the end.

Early call results in a situation where params set by mainboard function could be overwritten by device tree and other internal callback assignments.

Since Skylake/Kabylake boards were implemented with this order in place, where `mainboard_silicon_init_params()` is (un)intentionally overwritten with device tree and other internal callback assignments, simply moving this to the end of FSP-S callback could introduce params modifications that could cause functionality changes or even some issues.

A solution is to create another mainboard function, which would be called at the end of FSP-S callback, allowing mainboards full control over FSP-S params, just like newer gens do, without potentially breaking existing Skylake/Kabylake boards.

Existing Skylake/Kabylake FSP-S callback params modification order:
1. Mainboard FSP-S params changes.
2. Device tree and other internal callback params changes.

Is changed to:
1. Mainboard FSP-S params changes.
2. Device tree and other internal callback params changes.
3. Mainboard fixup FSP-S params changes.

For example take a look at MTL, `src/soc/intel/meteorlake/fsp_params.c`: 
```
/* UPD parameters to be initialized before SiliconInit */
void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
{
	struct soc_intel_meteorlake_config *config;
	FSP_S_CONFIG *s_cfg = &supd->FspsConfig;
	FSPS_ARCHx_UPD *s_arch_cfg = &supd->FspsArchUpd;

	config = config_of_soc();
	arch_silicon_init_params(s_arch_cfg);
	soc_silicon_init_params(s_cfg, config);
	mainboard_silicon_init_params(s_cfg);
}
```

`mainboard_silicon_init_params()` is called at the end.

Now take a look at SKL/KBL, `src/soc/intel/skylake/chip.c`: 
```
/* UPD parameters to be initialized before SiliconInit */
void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
{
	FSP_S_CONFIG *params = &supd->FspsConfig;
	FSP_S_TEST_CONFIG *tconfig = &supd->FspsTestConfig;
	struct soc_intel_skylake_config *config;
	uintptr_t vbt_data = (uintptr_t)vbt_get();
	int i;

	config = config_of_soc();

	mainboard_silicon_init_params(params);

	struct soc_power_limits_config *soc_confg;
	config_t *confg = config_of_soc();
	soc_confg = &confg->power_limits_config;
	/* Set PsysPmax if it is available from DT */
	if (soc_confg->psys_pmax) {
		/* PsysPmax is in unit of 1/8 Watt */
		tconfig->PsysPmax = soc_confg->psys_pmax * 8;
		printk(BIOS_DEBUG, "psys_pmax = %d\n", tconfig->PsysPmax);
	}

	params->GraphicsConfigPtr = (u32)vbt_data;

	/* Other params changes within callback function... */
	[...]
}
```

`mainboard_silicon_init_params()` is called at the beginning. This means that if you set a specific param in Skylake/Kabylake mainboard function, then it could be overwritten if callback code also touches it.

This change could be useful in the future for some new board specific fixes and/or CFR, where there is a need to change specific FSP-S params, without having to worry that they will be silently overwritten by callback.

A simple test of this new patch.

In `src/soc/intel/skylake/chip.c` `PcieRpHotPlug` is changed after `mainboard_silicon_init_params()` is called: 
```
void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
{
	FSP_S_CONFIG *params = &supd->FspsConfig;
	FSP_S_TEST_CONFIG *tconfig = &supd->FspsTestConfig;
	struct soc_intel_skylake_config *config;
	uintptr_t vbt_data = (uintptr_t)vbt_get();
	int i;

	config = config_of_soc();

	mainboard_silicon_init_params(params);
	[...]
	memcpy(params->PcieRpHotPlug, config->PcieRpHotPlug,
	       sizeof(params->PcieRpHotPlug));
```

Let's try to change it via `mainboard_silicon_init_params()` (RP6) and newly introduced `mainboard_silicon_init_params_fixup()` (RP7): 

`src/mainboard/google/fizz/mainboard.c`: 
```
void mainboard_silicon_init_params(FSP_S_CONFIG *params)
{
	params->PcieRpHotPlug[6] = 1;
}

void mainboard_silicon_init_params_fixup(FSP_S_CONFIG *params)
{
	params->PcieRpHotPlug[7] = 1;
}
```

Add some debug messages at the end of callback: 

`src/soc/intel/skylake/chip.c`: 
```
void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
{
	[...]
	printk(BIOS_DEBUG, "MX: params->PcieRpHotPlug[6] = 0x%x\n", params->PcieRpHotPlug[6]);
	printk(BIOS_DEBUG, "MX: params->PcieRpHotPlug[7] = 0x%x\n", params->PcieRpHotPlug[7]);
}
```

Test results: 
```
[DEBUG]  MX: params->PcieRpHotPlug[6] = 0x0
[DEBUG]  MX: params->PcieRpHotPlug[7] = 0x1
```

`mainboard_silicon_init_params()` (RP6) was overwritten by callback code and `mainboard_silicon_init_params_fixup()` (RP7) was not.

TEST=Build fizz and try to change params->PcieRpHotPlug from mainboard_silicon_init_params() and mainboard_silicon_init_params_fixup()