### PR TITLE
mb/google/*: Add CFR options for Intel ME HECI1 and PAVP

### DIFF
--- a/src/mainboard/google/brox/cfr.c
+++ b/src/mainboard/google/brox/cfr.c
@@ -16,6 +16,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/brox/cfr.c
+++ b/src/mainboard/google/brox/cfr.c
@@ -15,6 +15,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/brya/cfr.c
+++ b/src/mainboard/google/brya/cfr.c
@@ -43,6 +43,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/brya/cfr.c
+++ b/src/mainboard/google/brya/cfr.c
@@ -42,6 +42,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/dedede/cfr.c
+++ b/src/mainboard/google/dedede/cfr.c
@@ -39,6 +39,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/dedede/cfr.c
+++ b/src/mainboard/google/dedede/cfr.c
@@ -38,6 +38,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/drallion/cfr.c
+++ b/src/mainboard/google/drallion/cfr.c
@@ -21,6 +21,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/drallion/cfr.c
+++ b/src/mainboard/google/drallion/cfr.c
@@ -22,6 +22,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/eve/cfr.c
+++ b/src/mainboard/google/eve/cfr.c
@@ -16,6 +16,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/eve/cfr.c
+++ b/src/mainboard/google/eve/cfr.c
@@ -15,6 +15,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/fizz/cfr.c
+++ b/src/mainboard/google/fizz/cfr.c
@@ -21,6 +21,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/fizz/cfr.c
+++ b/src/mainboard/google/fizz/cfr.c
@@ -22,6 +22,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/glados/cfr.c
+++ b/src/mainboard/google/glados/cfr.c
@@ -16,6 +16,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/glados/cfr.c
+++ b/src/mainboard/google/glados/cfr.c
@@ -15,6 +15,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/hatch/cfr.c
+++ b/src/mainboard/google/hatch/cfr.c
@@ -35,6 +35,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/hatch/cfr.c
+++ b/src/mainboard/google/hatch/cfr.c
@@ -36,6 +36,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/octopus/cfr.c
+++ b/src/mainboard/google/octopus/cfr.c
@@ -18,6 +18,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/octopus/cfr.c
+++ b/src/mainboard/google/octopus/cfr.c
@@ -19,6 +19,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/poppy/cfr.c
+++ b/src/mainboard/google/poppy/cfr.c
@@ -37,6 +37,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/poppy/cfr.c
+++ b/src/mainboard/google/poppy/cfr.c
@@ -36,6 +36,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/puff/cfr.c
+++ b/src/mainboard/google/puff/cfr.c
@@ -17,6 +17,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/puff/cfr.c
+++ b/src/mainboard/google/puff/cfr.c
@@ -16,6 +16,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/reef/cfr.c
+++ b/src/mainboard/google/reef/cfr.c
@@ -18,6 +18,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/reef/cfr.c
+++ b/src/mainboard/google/reef/cfr.c
@@ -19,6 +19,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/rex/cfr.c
+++ b/src/mainboard/google/rex/cfr.c
@@ -16,6 +16,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/rex/cfr.c
+++ b/src/mainboard/google/rex/cfr.c
@@ -15,6 +15,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/sarien/cfr.c
+++ b/src/mainboard/google/sarien/cfr.c
@@ -21,6 +21,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/sarien/cfr.c
+++ b/src/mainboard/google/sarien/cfr.c
@@ -22,6 +22,7 @@ static struct sm_obj_form system = {
 		&me_state,
 		&me_state_counter,
 		&me_heci1,
+		&me_pavp,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/mainboard/google/volteer/cfr.c
+++ b/src/mainboard/google/volteer/cfr.c
@@ -29,6 +29,7 @@ static struct sm_obj_form system = {
 		&legacy_8254_timer,
 		&me_state,
 		&me_state_counter,
+		&me_heci1,
 		&pciexp_aspm,
 		&pciexp_clk_pm,
 		&pciexp_l1ss,

--- a/src/soc/intel/alderlake/finalize.c
+++ b/src/soc/intel/alderlake/finalize.c
@@ -18,6 +18,7 @@
 #include <intelblocks/pmclib.h>
 #include <intelblocks/systemagent.h>
 #include <intelblocks/tco.h>
+#include <option.h>
 #include <soc/p2sb.h>
 #include <soc/pci_devs.h>
 #include <soc/pcr_ids.h>
@@ -76,7 +77,7 @@ static void tbt_finalize(void)
 static void heci_finalize(void)
 {
 	heci_set_to_d0i3();
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/alderlake/fsp_params.c
+++ b/src/soc/intel/alderlake/fsp_params.c
@@ -614,7 +614,7 @@ static void fill_fsps_igd_params(FSP_S_CONFIG *s_cfg,
 	/* Check if IGD is present and fill Graphics init param accordingly */
 	s_cfg->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(SA_DEVFN_IGD);
 	s_cfg->LidStatus = CONFIG(VBOOT_LID_SWITCH) ? get_lid_switch() : CONFIG(RUN_FSP_GOP);
-	s_cfg->PavpEnable = CONFIG(PAVP);
+	s_cfg->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 }
 
 WEAK_DEV_PTR(tcss_usb3_port1);

--- a/src/soc/intel/apollolake/chip.c
+++ b/src/soc/intel/apollolake/chip.c
@@ -734,7 +734,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *silupd)
 
 	silconfig->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(SA_DEVFN_IGD);
 
-	silconfig->PavpEnable = CONFIG(PAVP);
+	silconfig->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 
 	/* SATA config */
 	if (is_devfn_enabled(PCH_DEVFN_SATA)) {

--- a/src/soc/intel/apollolake/cse.c
+++ b/src/soc/intel/apollolake/cse.c
@@ -8,6 +8,7 @@
 #include <intelblocks/cse.h>
 #include <intelblocks/p2sb.h>
 #include <intelblocks/pcr.h>
+#include <option.h>
 #include <soc/cse.h>
 #include <soc/heci.h>
 #include <soc/iomap.h>
@@ -218,7 +219,7 @@ void heci_cse_lockdown(void)
 	 * It is safe to disable HECI1 now since we won't be talking to the ME
 	 * anymore.
 	 */
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/cannonlake/finalize.c
+++ b/src/soc/intel/cannonlake/finalize.c
@@ -14,6 +14,7 @@
 #include <intelblocks/systemagent.h>
 #include <intelblocks/tco.h>
 #include <intelblocks/thermal.h>
+#include <option.h>
 #include <soc/p2sb.h>
 #include <soc/pci_devs.h>
 #include <soc/pcr_ids.h>
@@ -88,7 +89,7 @@ static void soc_finalize(void *unused)
 
 	pch_finalize();
 	apm_control(APM_CNT_FINALIZE);
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT) &&
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)) &&
 			CONFIG(SOC_INTEL_COMMON_BLOCK_HECI1_DISABLE_USING_PMC_IPC))
 		heci1_disable();
 

--- a/src/soc/intel/cannonlake/fsp_params.c
+++ b/src/soc/intel/cannonlake/fsp_params.c
@@ -734,7 +734,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 
 	s_cfg->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(SA_DEVFN_IGD);
 
-	s_cfg->PavpEnable = CONFIG(PAVP);
+	s_cfg->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 
 	/*
 	 * Prevent FSP from programming write-once subsystem IDs by providing

--- a/src/soc/intel/cannonlake/smihandler.c
+++ b/src/soc/intel/cannonlake/smihandler.c
@@ -3,6 +3,7 @@
 #include <device/device.h>
 #include <intelblocks/cse.h>
 #include <intelblocks/smihandler.h>
+#include <option.h>
 #include <soc/soc_chip.h>
 #include <soc/pci_devs.h>
 #include <soc/pm.h>
@@ -16,7 +17,8 @@
  */
 void smihandler_soc_at_finalize(void)
 {
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT) && CONFIG(HECI_DISABLE_USING_SMM))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)) &&
+	    CONFIG(HECI_DISABLE_USING_SMM))
 		heci1_disable();
 }
 

--- a/src/soc/intel/common/block/cse/cse.c
+++ b/src/soc/intel/common/block/cse/cse.c
@@ -1430,7 +1430,8 @@ static void cse_final_ready_to_boot(void)
 {
 	cse_control_global_reset_lock();
 
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT) || cse_is_hfs1_com_soft_temp_disable()) {
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)) ||
+	    cse_is_hfs1_com_soft_temp_disable()) {
 		cse_set_to_d0i3();
 		heci1_disable();
 	}

--- a/src/soc/intel/common/block/include/intelblocks/cfr.h
+++ b/src/soc/intel/common/block/include/intelblocks/cfr.h
@@ -46,6 +46,26 @@ static const struct sm_object me_heci1 = SM_DECLARE_ENUM({
 				SM_ENUM_VALUE_END			},
 });
 
+/* Intel ME PAVP (Protected Audio-Video Path) */
+static const struct sm_object me_pavp = SM_DECLARE_ENUM({
+	.opt_name	= "me_pavp",
+	.ui_name	= "Intel ME PAVP",
+	.ui_helptext	= "Enable or disable Intel PAVP (Protected Audio-Video"
+			  " Path). This technology is used to enforce digital"
+			  " rights protections on multimedia content. Streaming"
+			  " or other media playback services may require it to"
+			  " be enabled for correct functioning. You might want"
+			  " to disable this if you do not want DRM content, or"
+			  " if you do not trust the security of the Intel"
+			  " Management Engine, which is where this technology"
+			  " is implemented.",
+	.default_value	= CONFIG(PAVP),
+	.values		= (const struct sm_enum_value[]) {
+				{ "Disabled",		0		},
+				{ "Enabled",		1		},
+				SM_ENUM_VALUE_END			},
+});
+
 /*
  * Power state after power loss
  * Use this option or the one below, but not both

--- a/src/soc/intel/common/block/include/intelblocks/cfr.h
+++ b/src/soc/intel/common/block/include/intelblocks/cfr.h
@@ -31,6 +31,21 @@ static const struct sm_object me_state_counter = SM_DECLARE_NUMBER({
 	.default_value	= 0,
 });
 
+/* Intel ME HECI1(CSE) device */
+static const struct sm_object me_heci1 = SM_DECLARE_ENUM({
+	.opt_name	= "me_heci1",
+	.ui_name	= "Intel ME HECI1(CSE) device",
+	.ui_helptext	= "Allows to disable HECI1(CSE) device at the end of"
+			  " boot. Disabling this hides the device from the OS,"
+			  " preventing communication with the Intel Management"
+			  " Engine, but it does not disable ME.",
+	.default_value	= !CONFIG(DISABLE_HECI1_AT_PRE_BOOT),
+	.values		= (const struct sm_enum_value[]) {
+				{ "Disabled",		0		},
+				{ "Enabled",		1		},
+				SM_ENUM_VALUE_END			},
+});
+
 /*
  * Power state after power loss
  * Use this option or the one below, but not both

--- a/src/soc/intel/elkhartlake/finalize.c
+++ b/src/soc/intel/elkhartlake/finalize.c
@@ -12,6 +12,7 @@
 #include <intelblocks/pmclib.h>
 #include <intelblocks/systemagent.h>
 #include <intelblocks/tco.h>
+#include <option.h>
 #include <soc/p2sb.h>
 #include <soc/pci_devs.h>
 #include <soc/pcr_ids.h>
@@ -34,7 +35,7 @@ static void pch_finalize(void)
 static void heci_finalize(void)
 {
 	heci_set_to_d0i3();
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/elkhartlake/smihandler.c
+++ b/src/soc/intel/elkhartlake/smihandler.c
@@ -3,6 +3,7 @@
 #include <device/pci_def.h>
 #include <intelblocks/cse.h>
 #include <intelblocks/smihandler.h>
+#include <option.h>
 #include <soc/soc_chip.h>
 #include <soc/pci_devs.h>
 #include <soc/pm.h>
@@ -16,7 +17,7 @@
  */
 void smihandler_soc_at_finalize(void)
 {
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/jasperlake/fsp_params.c
+++ b/src/soc/intel/jasperlake/fsp_params.c
@@ -64,7 +64,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	/* Check if IGD is present and fill Graphics init param accordingly */
 	params->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(SA_DEVFN_IGD);
 
-	params->PavpEnable = CONFIG(PAVP);
+	params->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 
 	/* Use coreboot MP PPI services if Kconfig is enabled */
 	if (CONFIG(USE_INTEL_FSP_TO_CALL_COREBOOT_PUBLISH_MP_PPI))

--- a/src/soc/intel/jasperlake/smihandler.c
+++ b/src/soc/intel/jasperlake/smihandler.c
@@ -3,6 +3,7 @@
 #include <device/pci_def.h>
 #include <intelblocks/cse.h>
 #include <intelblocks/smihandler.h>
+#include <option.h>
 #include <soc/soc_chip.h>
 #include <soc/pci_devs.h>
 #include <soc/pm.h>
@@ -16,7 +17,7 @@
  */
 void smihandler_soc_at_finalize(void)
 {
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/meteorlake/finalize.c
+++ b/src/soc/intel/meteorlake/finalize.c
@@ -13,6 +13,7 @@
 #include <intelblocks/systemagent.h>
 #include <intelblocks/tco.h>
 #include <intelblocks/thermal.h>
+#include <option.h>
 #include <spi-generic.h>
 #include <intelpch/lockdown.h>
 #include <soc/p2sb.h>
@@ -55,7 +56,7 @@ static void sa_finalize(void)
 static void heci_finalize(void)
 {
 	heci_set_to_d0i3();
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/meteorlake/fsp_params.c
+++ b/src/soc/intel/meteorlake/fsp_params.c
@@ -379,7 +379,7 @@ static void fill_fsps_igd_params(FSP_S_CONFIG *s_cfg,
 	/* Check if IGD is present and fill Graphics init param accordingly */
 	s_cfg->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(PCI_DEVFN_IGD);
 	s_cfg->LidStatus = CONFIG(VBOOT_LID_SWITCH) ? get_lid_switch() : CONFIG(RUN_FSP_GOP);
-	s_cfg->PavpEnable = CONFIG(PAVP);
+	s_cfg->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 }
 
 static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,

--- a/src/soc/intel/pantherlake/finalize.c
+++ b/src/soc/intel/pantherlake/finalize.c
@@ -14,6 +14,7 @@
 #include <intelblocks/tco.h>
 #include <intelblocks/thermal.h>
 #include <intelpch/lockdown.h>
+#include <option.h>
 #include <soc/p2sb.h>
 #include <soc/pci_devs.h>
 #include <soc/pcr_ids.h>
@@ -54,7 +55,7 @@ static void sa_finalize(void)
 static void heci_finalize(void)
 {
 	heci_set_to_d0i3();
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 }
 

--- a/src/soc/intel/pantherlake/fsp_params.c
+++ b/src/soc/intel/pantherlake/fsp_params.c
@@ -335,7 +335,7 @@ static void fill_fsps_igd_params(FSP_S_CONFIG *s_cfg,
 	/* Check if IGD is present and fill Graphics init param accordingly */
 	s_cfg->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(PCI_DEVFN_IGD);
 	s_cfg->LidStatus = CONFIG(VBOOT_LID_SWITCH) ? get_lid_switch() : CONFIG(RUN_FSP_GOP);
-	s_cfg->PavpEnable = CONFIG(PAVP);
+	s_cfg->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 }
 
 static void fill_fsps_tcss_params(FSP_S_CONFIG *s_cfg,

--- a/src/soc/intel/skylake/chip.c
+++ b/src/soc/intel/skylake/chip.c
@@ -499,7 +499,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 
 	params->PeiGraphicsPeimInit = CONFIG(RUN_FSP_GOP) && is_devfn_enabled(SA_DEVFN_IGD);
 
-	params->PavpEnable = CONFIG(PAVP);
+	params->PavpEnable = !!get_uint_option("me_pavp", CONFIG(PAVP));
 
 	soc_irq_settings(params);
 }

--- a/src/soc/intel/skylake/chip.c
+++ b/src/soc/intel/skylake/chip.c
@@ -394,7 +394,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	 * setting, we set the appropriate PsfUnlock policy in FSP,
 	 * do the changes and then lock it back in coreboot during finalize.
 	 */
-	tconfig->PchSbAccessUnlock = CONFIG(DISABLE_HECI1_AT_PRE_BOOT);
+	tconfig->PchSbAccessUnlock = !get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT));
 
 	const bool lockdown_by_fsp = get_lockdown_config() == CHIPSET_LOCKDOWN_FSP;
 	tconfig->PchLockDownBiosInterface = lockdown_by_fsp;

--- a/src/soc/intel/skylake/finalize.c
+++ b/src/soc/intel/skylake/finalize.c
@@ -16,6 +16,7 @@
 #include <intelblocks/pmclib.h>
 #include <intelblocks/tco.h>
 #include <intelblocks/thermal.h>
+#include <option.h>
 #include <soc/me.h>
 #include <soc/p2sb.h>
 #include <soc/pci_devs.h>
@@ -60,7 +61,7 @@ static void pch_finalize_script(struct device *dev)
 	pch_thermal_configuration();
 
 	/* we should disable Heci1 based on the config */
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 
 	/* Hide p2sb device as the OS must not change BAR0. */

--- a/src/soc/intel/tigerlake/finalize.c
+++ b/src/soc/intel/tigerlake/finalize.c
@@ -18,6 +18,7 @@
 #include <intelblocks/pmclib.h>
 #include <intelblocks/systemagent.h>
 #include <intelblocks/tco.h>
+#include <option.h>
 #include <soc/p2sb.h>
 #include <soc/pci_devs.h>
 #include <soc/pcr_ids.h>
@@ -57,7 +58,7 @@ static void soc_finalize(void *unused)
 	pch_finalize();
 	apm_control(APM_CNT_FINALIZE);
 	tbt_finalize();
-	if (CONFIG(DISABLE_HECI1_AT_PRE_BOOT))
+	if (!get_uint_option("me_heci1", !CONFIG(DISABLE_HECI1_AT_PRE_BOOT)))
 		heci1_disable();
 
 	/* Indicate finalize step with post code */


### PR DESCRIPTION
Allow users to enable/disable HECI1 and PAVP via CFR options menu.

Kconfig DISABLE_HECI1_AT_PRE_BOOT and PAVP are compile-time only options.

This adds support for a run-time configurable CFR, where Kconfig is used as a default value, and updates SoC code to use this new CFR instead of Kconfig.

Should address issues like: 
https://github.com/MrChromebox/firmware/issues/887

I could not find any reference to `CONFIG(PAVP)` in Tigerlake SoC code, so I did not include PAVP CFR for VOLTEER. FSP-S code also does not touch `PavpEnable` param (it is available). We can change this.

There are Google boards with Pantherlake SoC, OCELOT/FATCAT, that could also use CFR for both HECI1 and PAVP, but they do not have CFR/`cfr.c`.

You will have to verify if all looks ok, as I can only test Skylake/Kabylake (FIZZ).

It would be possible to add few other CFRs for controlling ME remote functionality like AMT/AMT SoL/ASF/Manageability Mode, but non-vPro firmwares usually lack such features anyway.

Also, not sure if PAVP works in Linux for Google boards. I have tried to extract some info, but cannot see any difference between PAVP disabled/enabled. There is a possibility that it is disabled at a lower level like Intel PTT (iTPM), at least for FIZZ.

With Intel ME and HECI1 always enabled, and only toggling PAVP, I am getting the same results: 
```
$ lsmod | grep -iE 'mei|heci|pxp|pavp|hdcp'
mei_me                 57344  0
mei                   188416  1 mei_me

$ ls -la /dev/mei*
crw------- 1 root root 240, 0 Feb 22 15:31 /dev/mei0

$ sudo ls /sys/bus/mei/devices/
0000:00:16.0-01e88543-8050-4380-9d6f-4f9cec704917
0000:00:16.0-082ee5a7-7c25-470a-9643-0c06f0466ea1
0000:00:16.0-309dcde8-ccb1-4062-8f78-600115a34327
0000:00:16.0-3c4852d6-d47b-4f46-b05e-b5edc1aa440e
0000:00:16.0-42b3ce2f-bd9f-485a-96ae-26406230b1ff
0000:00:16.0-55213584-9a29-4916-badf-0fb7ed682aeb
0000:00:16.0-5565a099-7fe2-45c1-a22b-d7e9dfea9a2e
0000:00:16.0-8c2f4425-77d6-4755-aca3-891fdbc66a58
0000:00:16.0-8e6a6715-9abc-4043-88ef-9e39c6f63e0f
0000:00:16.0-dba4d603-d7ed-4931-8823-17ad585705d5
0000:00:16.0-f908627d-13bf-4a04-b91f-a64e9245323d

$ sudo dmesg | grep -iE 'mei|heci|pxp|pavp|hdcp'
[nothing]

$ sudo cat /sys/kernel/debug/dri/0/i915_capabilities | grep -iE 'mei|heci|pxp|pavp|hdcp|content'
has_heci_pxp: no
has_heci_gscfi: no
has_pxp: no

$ vainfo --display drm --device /dev/dri/renderD128 
Trying display: drm
libva info: VA-API version 1.22.0
libva info: Trying to open /usr/lib/x86_64-linux-gnu/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_22
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.22 (libva 2.22.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.2.3 ()
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            :	VAEntrypointVLD
      VAProfileMPEG2Main              :	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointEncSliceLP
      VAProfileH264High               :	VAEntrypointVLD
      VAProfileH264High               :	VAEntrypointEncSliceLP
      VAProfileJPEGBaseline           :	VAEntrypointVLD
      VAProfileJPEGBaseline           :	VAEntrypointEncPicture
      VAProfileH264ConstrainedBaseline:	VAEntrypointVLD
      VAProfileH264ConstrainedBaseline:	VAEntrypointEncSliceLP
      VAProfileVP8Version0_3          :	VAEntrypointVLD
      VAProfileHEVCMain               :	VAEntrypointVLD
      VAProfileHEVCMain10             :	VAEntrypointVLD
      VAProfileVP9Profile0            :	VAEntrypointVLD
      VAProfileVP9Profile2            :	VAEntrypointVLD

$ drm_info | grep -iE 'mei|heci|pxp|pavp|hdcp|content'
│   │       ├───"content type": enum {No Data, Graphics, Photo, Cinema, Game} = No Data
│   │       ├───"Content Protection": enum {Undesired, Desired, Enabled} = Undesired
│   │       └───"HDCP Content Type": enum {HDCP Type0, HDCP Type1} = HDCP Type0
│   │       ├───"Content Protection": enum {Undesired, Desired, Enabled} = Undesired
│   │       └───"HDCP Content Type": enum {HDCP Type0, HDCP Type1} = HDCP Type0
│   │       ├───"content type": enum {No Data, Graphics, Photo, Cinema, Game} = No Data
│   │       ├───"Content Protection": enum {Undesired, Desired, Enabled} = Undesired
│   │       └───"HDCP Content Type": enum {HDCP Type0, HDCP Type1} = HDCP Type0
│   │       ├───"Content Protection": enum {Undesired, Desired, Enabled} = Undesired
│   │       └───"HDCP Content Type": enum {HDCP Type0, HDCP Type1} = HDCP Type0
│           ├───"content type": enum {No Data, Graphics, Photo, Cinema, Game} = No Data
│           ├───"Content Protection": enum {Undesired, Desired, Enabled} = Undesired
│           └───"HDCP Content Type": enum {HDCP Type0, HDCP Type1} = HDCP Type0
```