### PR TITLE
Fix GTCH7503 touchscreens for blipper

### DIFF
--- a/src/mainboard/google/dedede/variants/blipper/overridetree.cb
+++ b/src/mainboard/google/dedede/variants/blipper/overridetree.cb
@@ -142,6 +142,10 @@ chip soc/intel/jasperlake
 							"ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_D5)"
 				register "generic.reset_delay_ms" = "120"
 				register "generic.reset_off_delay_ms" = "3"
+				register "generic.stop_gpio" =
+							"ACPI_GPIO_OUTPUT_ACTIVE_LOW(GPP_A11)"
+				register "generic.stop_delay_ms" = "280"
+				register "generic.stop_off_delay_ms" = "2"
 				register "generic.enable_gpio" =
 							"ACPI_GPIO_OUTPUT_ACTIVE_HIGH(GPP_D6)"
 				register "generic.enable_delay_ms" = "12"


### PR DESCRIPTION
This fixes G2Touch GTCH7503 touchscreens for blipper/beetley units by adding stop_gpio and associated delays for them to the config (matching ELAN0001 values on the same board)

Tested working in Linux and Windows on a Lenovo Ideapad Flex 3i 15.

Fixes:
https://forum.chrultrabook.com/t/jasperlake-lenovo-flex-3i-15-beetley-touchscreen-not-working-on-some-units/79
https://forum.chrultrabook.com/t/touchscreen-in-jasper-lake-lenovo-ideapad-blipper/1191
https://forum.chrultrabook.com/t/touch-screen-on-lenovo-ideapad-3-15ijl6-blipper/1886
https://forum.chrultrabook.com/t/touch-screen-on-lenovo-ideapad-3-15ijl6-blipper/1805