### PR TITLE
soc/intel/cannonlake: skip CPU replacement check on CML

### DIFF
--- a/src/mainboard/google/puff/variants/baseboard/devicetree.cb
+++ b/src/mainboard/google/puff/variants/baseboard/devicetree.cb
@@ -27,6 +27,8 @@ chip soc/intel/cannonlake
 	register "satapwroptimize" = "1"
 	# Enable System Agent dynamic frequency
 	register "SaGv" = "SaGv_Enabled"
+	# Avoid slow MRC retraining on cold boots when cached memory settings are valid
+	register "SkipCpuReplacementCheck" = "1"
 	# Enable S0ix
 	register "s0ix_enable" = "true"
 	# Enable DPTF

--- a/src/soc/intel/cannonlake/chip.h
+++ b/src/soc/intel/cannonlake/chip.h
@@ -125,6 +125,9 @@ struct soc_intel_cannonlake_config {
 	/* Rank Margin Tool. 1:Enable, 0:Disable */
 	bool RMT;
 
+	/* Skip CPU replacement check. 1:Enable, 0:Disable */
+	bool SkipCpuReplacementCheck;
+
 	/* USB related */
 	struct usb2_port_config usb2_ports[16];
 	struct usb3_port_config usb3_ports[10];

--- a/src/soc/intel/cannonlake/romstage/fsp_params.c
+++ b/src/soc/intel/cannonlake/romstage/fsp_params.c
@@ -136,6 +136,8 @@ void platform_fsp_memory_init_params_cb(FSPM_UPD *mupd, uint32_t version)
 	m_cfg->Heci1BarAddress = HECI1_BASE_ADDRESS;
 
 	mainboard_memory_init_params(mupd);
+
+	tconfig->SkipCpuReplacementCheck = config->SkipCpuReplacementCheck;
 }
 
 __weak void mainboard_memory_init_params(FSPM_UPD *mupd)


### PR DESCRIPTION
## Summary

Add a Cannonlake/Comet Lake platform config knob for the FSP-M `SkipCpuReplacementCheck` test UPD, then enable it at the Google Puff baseboard level.

On KAISA, cold boots were spending about 30 seconds inside `FspMemoryInit` even though `RW_MRC_CACHE` existed and both DIMMs matched the cached SPD data. Warm reboots reused the cache and completed memory init in roughly 40 ms. Enabling this option at the mainboard level keeps FSP-M on the no-configuration-change path for this case.

## Implementation

- Add `SkipCpuReplacementCheck` to `soc_intel_cannonlake_config`.
- Pass that platform config value into `FspmTestConfig.SkipCpuReplacementCheck`.
- Enable the option in `google/puff` baseboard `devicetree.cb`.

## Validation

Tested on Acer Chromebox CXI4 / KAISA with a Comet Lake build based on `MrChromebox-2603`.

Before this change:
- Cold power-on: `FspMemoryInit` took about 30.5 s.
- Warm reboot: `FspMemoryInit` took about 40 ms.
- Logs showed `SPD_CACHE: DIMM0 is the same`, `DIMM1 is the same`, but the MRC cache was updated after the slow cold boot.

With this change:
- Cold power-on: `FspMemoryInit` took about 46 ms.
- Warm reboot: `FspMemoryInit` took about 41 ms.
- Logs showed `SPD_CACHE: DIMM0 is the same`, `DIMM1 is the same`, and `MRC: 'RW_MRC_CACHE' does not need update`.

Build verification after moving this to platform/mainboard config:
- Built KAISA release UEFI/iPXE-only ROM in `coreboot/coreboot-sdk`.
- Build log: `/home/jack/coreboot_build/out/logs/build-kaisa-2603-release-ipxe-only-skipcpu-platformcfg-20260601-155458.log`
- ROM SHA256: `214ebe3926b0727c9e37060b5acdf71f7a6fd26342458bb305d74ede6cfa73ba`