### PR TITLE
RFC: mb/google/puff/kaisa: investigate hiding absent eMMC

### DIFF
--- a/src/mainboard/google/puff/variants/kaisa/Makefile.mk
+++ b/src/mainboard/google/puff/variants/kaisa/Makefile.mk
@@ -1,4 +1,5 @@
 ## SPDX-License-Identifier: GPL-2.0-only
 
 ramstage-y += gpio.c
+ramstage-y += variant.c
 bootblock-y += gpio.c

--- a/src/mainboard/google/puff/variants/kaisa/variant.c
+++ b/src/mainboard/google/puff/variants/kaisa/variant.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#include <baseboard/variants.h>
+#include <chip.h>
+#include <console/console.h>
+#include <ec/google/chromeec/ec.h>
+#include <soc/pci_devs.h>
+#include <static.h>
+
+#define KAISA_NVME_SKU_ID	0x01000006
+
+void variant_devtree_update(void)
+{
+	struct device *emmc_host;
+	config_t *cfg = config_of_soc();
+	const uint32_t sku_id = google_chromeec_get_board_sku();
+
+	/*
+	 * Kaisa SKU 0x01000006 uses NVMe storage. Hide the unused onboard
+	 * eMMC controller while keeping the separate SD/TF reader enabled.
+	 */
+	if (sku_id != KAISA_NVME_SKU_ID)
+		return;
+
+	emmc_host = pcidev_path_on_root(PCH_DEVFN_EMMC);
+	if (!emmc_host) {
+		printk(BIOS_WARNING, "Kaisa: eMMC device not found\n");
+		return;
+	}
+
+	printk(BIOS_INFO, "Kaisa: disable eMMC controller for NVMe SKU %#x\n", sku_id);
+	emmc_host->enabled = 0;
+	cfg->ScsEmmcHs400Enabled = 0;
+}


### PR DESCRIPTION
## RFC / investigation draft

This PR is intentionally left as a draft.  The current patch is useful as a tested experiment, but it should not be merged as-is because it hard-codes a single Kaisa CBI SKU (`0x01000006` / `sku16777222`) as the NVMe SKU.

The maintainer feedback is valid: I do not currently have a complete public SKU-to-storage matrix for all KAISA units, so the change should not rely on SKU matching alone.

## What was observed

On the tested KAISA-WVRW unit:

- The onboard eMMC controller is exposed as PCI `00:1a.0` (`8086:02c4`).
- The removable SD/TF card reader is a separate controller at PCI `00:14.5` (`8086:02f5`).
- The machine boots from NVMe at PCI `02:00.0`.
- There is no observed onboard eMMC media on this NVMe unit.

The current experimental patch disables only `PCH_DEVFN_EMMC`; it does not disable the SD/TF reader.

## Source-level notes

Puff/Kaisa already has a suitable timing hook for this kind of change:

- `variant_devtree_update()` is called from `mainboard_silicon_init_params()` before FSP-S parameters are finalized.
- Cannon Lake sets `ScsEmmcEnabled` from `is_devfn_enabled(PCH_DEVFN_EMMC)`, so disabling the eMMC device there affects the FSP-S eMMC enable path.

Newer Google boards often solve this more cleanly with FW_CONFIG-backed devicetree probes, for example `probe STORAGE STORAGE_EMMC` / `probe STORAGE STORAGE_NVME`.  I have not found an equivalent `STORAGE` FW_CONFIG field for KAISA in the current Puff/Kaisa devicetree.

## Open question

The right fix should hide the eMMC controller only when eMMC storage is actually absent, or when a reliable board-provided configuration bit says the storage type is not eMMC.

I am keeping this PR as an RFC while looking for one of these:

- an official KAISA storage FW_CONFIG / CBI field,
- a documented KAISA SKU/HWID storage matrix,
- or an acceptable runtime absence-detection path that does not overcomplicate early boot.

## Validation of the experiment

- Built Kaisa on `MrChromebox-2603`.
- Flashed the generated ROM on the tested KAISA-WVRW unit; flashrom write and verify passed.
- After reboot on the tested unit:
  - `00:1a.0` onboard eMMC controller was no longer enumerated.
  - `00:14.5` SD/TF card reader remained enumerated.
  - NVMe remained present at `02:00.0`.