### PR TITLE
ec/google/chromeec: hide absent battery and MKBP devices

### DIFF
--- a/src/ec/google/chromeec/acpi/battery.asl
+++ b/src/ec/google/chromeec/acpi/battery.asl
@@ -40,6 +40,10 @@ Method (BTSW, 1)
 //   Arg0 = battery index
 Method (BSTA, 1, Serialized)
 {
+	If (!(BATT || SBAT)) {
+		Return (0)
+	}
+
 	If (Acquire (^BATM, 1000)) {
 		Return (0)
 	}

--- a/src/ec/google/chromeec/acpi/cros_ec.asl
+++ b/src/ec/google/chromeec/acpi/cros_ec.asl
@@ -23,6 +23,15 @@ Device (CREC)
 		Name (_HID, "GOOG0007")
 		Name (_UID, 1)
 		Name (_DDN, "EC MKBP Device")
+
+		Method (_STA, 0)
+		{
+			If (KEYB) {
+				Return (0xF)
+			}
+
+			Return (0)
+		}
 	}
 #endif
 


### PR DESCRIPTION
## Summary

Use Chrome EC feature bits to hide Chrome OS laptop-oriented ACPI devices when the EC reports that the hardware is not present.

- Return `_STA = 0` for the ACPI battery device when neither `BATT` nor `SBAT` is reported by the EC.
- Return `_STA = 0` for the Chrome EC MKBP keyboard/buttons device (`GOOG0007`) when the EC does not report `KEYB`.
- Leave the main Chrome EC command device (`GOOG0004`) and AC adapter (`ACPI0003`) visible, because charger/PD/EC command functionality can still be valid on Chromebox-style systems.

## Rationale

Kaisa-style Chromebox systems can share Chrome EC ACPI code with Chromebook designs, but the EC feature bitmap already tells us whether battery and EC keyboard/button capabilities exist. Hiding these devices via `_STA` avoids exposing non-functional laptop devices to the OS without adding board-specific policy knobs.

## Validation

Built `google/puff` Kaisa from `MrChromebox-2603` with a release iPXE payload.

- Build tree: `/home/jack/coreboot_build/src/coreboot-2603-chromeec-acpi-pr`
- Build log: `/home/jack/coreboot_build/out/logs/build-kaisa-2603-release-ipxe-only-chromeec-acpi-sta-20260601-170324.log`
- Archived ROM: `/home/jack/coreboot_build/out/roms/kaisa-2603-release-ipxe-only-chromeec-acpi-sta-20260601-171620/kaisa-2603-release-ipxe-only-chromeec-acpi-sta.rom`
- SHA256: `458babe81b708f3a5acbd1a3971afcfcca5e4daff1bc9c74f9887fdd70ac03bf`

Flashed the ROM on a Kaisa target using the local MrChromebox-style flash script, preserving/injecting platform data from the backup.

- Flash backup: `/home/jack/文档/CoreBoot-Build/out/backups/backup_20260602_011854.rom`
- Flash verification: `VERIFIED`

After reboot on the target:

- `PNP0C0A:00` battery path `\_SB_.PCI0.LPCB.EC0_.BAT0` reports `status=0`.
- `GOOG0007:00` path `\_SB_.PCI0.LPCB.EC0_.CREC.CKSC` reports `status=0`.
- `cros_ec_buttons` is no longer present in `/sys/class/input`.
- `GOOG0004:00` remains present with `status=15`.
- `ACPI0003:00` remains present with `status=15`.
- The regular `Power Button` input remains present.
- `/sys/class/power_supply` still exposes `AC`, `CROS_DEDICATED_CHARGER`, and `CROS_USBPD_CHARGER0`.

Note: the flashed validation ROM contained only this PR's change on top of `MrChromebox-2603`, so unrelated Kaisa eMMC hiding work was not included in this runtime test image.
