### PR TITLE
minipc: hide ACPI for devices absent on Chromebox

### DIFF
--- a/src/drivers/net/r8168.c
+++ b/src/drivers/net/r8168.c
@@ -417,7 +417,7 @@ static void r8168_init(struct device *dev)
 		enable_aspm_l1_2(io_base);
 }
 
-#if CONFIG(HAVE_ACPI_TABLES)
+#if CONFIG(HAVE_ACPI_TABLES) && !CONFIG(MINIPC_HIDE_R8168_ACPI)
 #define R8168_ACPI_HID "R8168"
 static void r8168_net_fill_ssdt(const struct device *dev)
 {
@@ -479,7 +479,7 @@ static struct device_operations r8168_ops  = {
 	.set_resources    = pci_dev_set_resources,
 	.enable_resources = pci_dev_enable_resources,
 	.init             = r8168_init,
-#if CONFIG(HAVE_ACPI_TABLES)
+#if CONFIG(HAVE_ACPI_TABLES) && !CONFIG(MINIPC_HIDE_R8168_ACPI)
 	.acpi_name        = r8168_net_acpi_name,
 	.acpi_fill_ssdt   = r8168_net_fill_ssdt,
 #endif

--- a/src/ec/google/chromeec/Kconfig
+++ b/src/ec/google/chromeec/Kconfig
@@ -254,6 +254,32 @@ config EC_GOOGLE_CHROMEEC_NEEDS_BATTERY_WORKAROUND
 	  logic.
 	  If unsure, say N.
 
+config MINIPC_HIDE_AC
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide AC adapter (ACPI0003) on mini PC / Chromebox"
+	default n
+
+config MINIPC_HIDE_BATTERY
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide battery (PNP0C0A) on mini PC / Chromebox"
+	default n
+
+config MINIPC_HIDE_VBTN
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide Chromebook keyboard/vbtn (GOOG000A, INT33D6) on mini PC / Chromebox"
+	default n
+
+config MINIPC_HIDE_R8168_ACPI
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide RTL8168 ACPI companion device (ACPI\\R8168) on mini PC / Chromebox"
+	default n
+	help
+	  Do not generate the RTL8168 SSDT ACPI device (_HID R8168) for the
+	  Realtek PCI NIC. Windows has no inbox driver for ACPI\\R8168 and
+	  shows Code 28 in Device Manager; the PCI Realtek driver still works.
+	  Linux/ChromeOS may use this ACPI node for wake/power control; say N
+	  if NIC ACPI wake is required on those OSes.
+`n
 config EC_GOOGLE_CHROMEEC_LPC_GENERIC_MEMORY_RANGE
 	def_bool n
 	help

--- a/src/ec/google/chromeec/acpi/ac.asl
+++ b/src/ec/google/chromeec/acpi/ac.asl
@@ -14,6 +14,10 @@ Device (AC)
 
 	Method (_STA)
 	{
+#if CONFIG(MINIPC_HIDE_AC)
+		Return (0)
+#else
 		Return (0x0F)
+#endif
 	}
 }

--- a/src/ec/google/chromeec/acpi/battery.asl
+++ b/src/ec/google/chromeec/acpi/battery.asl
@@ -436,7 +436,11 @@ Device (BAT0)
 
 	Method (_STA, 0, Serialized)
 	{
+#if CONFIG(MINIPC_HIDE_BATTERY)
+		Return (0)
+#else
 		Return (BSTA (0))
+#endif
 	}
 
 	Method (_BIF, 0, Serialized)
@@ -527,7 +531,11 @@ Device (BAT1)
 
 	Method (_STA, 0, Serialized)
 	{
+#if CONFIG(MINIPC_HIDE_BATTERY)
+		Return (0)
+#else
 		Return (BSTA (1))
+#endif
 	}
 
 	Method (_BIF, 0, Serialized)

--- a/src/ec/google/chromeec/acpi/superio.asl
+++ b/src/ec/google/chromeec/acpi/superio.asl
@@ -95,7 +95,11 @@ Scope (\_SB.PCI0)
 		Name (_CID, Package() { EISAID("PNP0303"), EISAID("PNP030B") } )
 
 		Method (_STA, 0, NotSerialized) {
+#if CONFIG(MINIPC_HIDE_VBTN)
+			Return (0)
+#else
 			Return (0x0F)
+#endif
 		}
 
 		Name (_CRS, ResourceTemplate()

--- a/src/ec/google/chromeec/acpi/vbtn.asl
+++ b/src/ec/google/chromeec/acpi/vbtn.asl
@@ -23,7 +23,11 @@ Device (VBTN)
 	}
 	Method(_STA, 0)
 	{
+#if CONFIG(MINIPC_HIDE_VBTN)
+		Return (0)
+#else
 		Return (0xF)
+#endif
 	}
 }
 
@@ -33,6 +37,10 @@ Device (VBTO)
 	Name (_CID, "PNP0C60")
 	Method (_STA, 0)
 	{
+#if CONFIG(MINIPC_HIDE_VBTN)
+		Return (0)
+#else
 		Return (0xF)
+#endif
 	}
 }

--- a/src/soc/intel/cannonlake/Kconfig
+++ b/src/soc/intel/cannonlake/Kconfig
@@ -307,6 +307,17 @@ config MB_HAS_ACTIVE_HIGH_SD_PWR_ENABLE
 	  This will enable a workaround in ASL _PS3 and _PS0 methods to force
 	  SD_PWR_ENABLE to stay low in D3.
 
+config SOC_INTEL_HIDE_EMMC
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide eMMC controller from OS (show only SD/TF slot as SD host)"
+	default n
+	help
+	  On mini PC / Chromebox with only one physical SD/TF card slot, the PCH
+	  still exposes both eMMC and SDXC in ACPI; Windows shows two "SD host
+	  controller" devices. Select this to hide the eMMC device (_STA = 0) so
+	  only the real SD/TF slot (SDXC) appears. eMMC will not be usable as
+	  storage in the OS when enabled.
+
 config FSP_HEADER_PATH
 	default "3rdparty/fsp/CoffeeLakeFspBinPkg/Include/" if SOC_INTEL_COFFEELAKE || SOC_INTEL_WHISKEYLAKE
 	default "3rdparty/fsp/CometLakeFspBinPkg/CometLake1/Include/" if SOC_INTEL_COMETLAKE_1

--- a/src/soc/intel/cannonlake/acpi/scs.asl
+++ b/src/soc/intel/cannonlake/acpi/scs.asl
@@ -21,6 +21,13 @@ Scope (\_SB.PCI0) {
 		Name (TEMP, 0)
 		Name (DSUU, ToUUID("f6c13ea5-65cd-461f-ab7a-29f7e8d5bd61"))
 
+#if CONFIG(SOC_INTEL_HIDE_EMMC)
+		Method (_STA, 0, NotSerialized)
+		{
+			Return (0)
+		}
+#endif
+
 		OperationRegion(SCSR, PCI_Config, 0x00, 0x100)
 		Field(SCSR, WordAcc, NoLock, Preserve) {
 			VDID, 32,	/* PCI VID DID */

--- a/src/soc/intel/cannonlake/fsp_params.c
+++ b/src/soc/intel/cannonlake/fsp_params.c
@@ -602,7 +602,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	};
 
 	/* eMMC and SD */
-	s_cfg->ScsEmmcEnabled = is_devfn_enabled(PCH_DEVFN_EMMC);
+	s_cfg->ScsEmmcEnabled = CONFIG(SOC_INTEL_HIDE_EMMC) ? 0 : is_devfn_enabled(PCH_DEVFN_EMMC);
 	if (s_cfg->ScsEmmcEnabled) {
 		s_cfg->ScsEmmcHs400Enabled = config->ScsEmmcHs400Enabled;
 		s_cfg->PchScsEmmcHs400DllDataValid = config->EmmcHs400DllNeed;


### PR DESCRIPTION
## Summary

Hide ACPI nodes for hardware that is absent on **Google Kaisa repurposed as an Acer CXI4 Chromebox** (no battery, no lid, NVMe-only SKU): AC adapter, battery, volume buttons (VBTN), RTL8168 **companion ACPI device**, and eMMC host.

All hides are gated on `CONFIG_SYSTEM_TYPE_MINIPC` Kconfig options that **default to `n`**; Kaisa UEFI defconfig enables them explicitly (see #38).

## Hardware / test platform

| Item | Value |
|------|--------|
| Board | `BOARD_GOOGLE_KAISA` (Puff baseboard, `SYSTEM_TYPE_MINIPC=y`) |
| AP | Intel Core i7-10610U (CML-U) |
| Form factor | Chromebox   no internal battery, no lid switch, boot from NVMe |
| DUT | Lab unit `JACK-KAISA` (192.168.2.119) |
| EC | Google Chrome EC legacy puff firmware |
| OS used for validation | **Windows 10 LTSC** (primary), Ubuntu 24.04 (secondary) |

## Problem (before this change)

On stock MrChromebox Kaisa UEFI builds, Windows Device Manager showed:

1. **`ACPI\R8168` ghost device   Code 28** (driver not installed). The Realtek GbE NIC works via PCI (`PCI\VEN_10EC&DEV_8168`), but an extra ACPI companion node confuses PnP and support tools.
2. **Duplicate / phantom storage controllers**   eMMC ACPI host (`DEV_02C4`) on NVMe-only boxes; users see an extra SD/eMMC class device with no media.
3. **Fake mobile ACPI devices**   `ACPI0003` (AC), `PNP0C0A` (battery), VBTN on a desktop chromebox.

These do not affect ChromeOS images (different ACPI expectations) but are visible on **Windows and generic Linux** when using UEFI payload.

## Validation (after flash with this patch + #37 + #38)

Automated inventory diff (`scripts/data/kaisa-chromeos-expected-devices.json`, profile `windows_fork`, 2026-06-22):

| Device | ChromeOS ref | Windows expectation | With this patch |
|--------|--------------|---------------------|-----------------|
| ACPI AC adapter | hidden | absent | **OK** (absent) |
| ACPI battery | hidden | absent | **OK** (absent) |
| Intel eMMC host (02C4) | present on CR | absent on box | **OK** (absent) |
| Realtek R8168 **duplicate ACPI** | present on CR | absent | **OK** (absent) |
| Realtek PCIe GbE (PCI function) | present | present | **OK** (works, PXE-capable) |

PnP inventory: **18/21 expected devices OK**; remaining UNEXPECTED items are Type-C retimer/DP bridge ACPI exposure (separate from this PR).

Windows still lists expected core devices: UHD 630, AX201 Wi-Fi, xHCI, Intel SST/DSP, HDMI audio endpoints, Chrome EC stack, NVMe boot drive.

## Design notes (for review)

- **`CONFIG_MINIPC_HIDE_*` and `CONFIG_SOC_INTEL_HIDE_EMMC` default `n`**   only Kaisa/minipc defconfigs opt in (#38). Laptop Puff variants unchanged.
- **eMMC hide**   FSP `ScsEmmcEnabled` forced off when `SOC_INTEL_HIDE_EMMC`; ACPI `SCS` `_STA` hidden. Matches NVMe-only CXI4 SKUs.
- **R8168 ACPI hide**   companion node suppressed in `r8168.c`; PCI NIC and (with #37/#38) EDK2 RtkUndi still work.
- Future improvement (not blocking): runtime/CBI-based detection instead of compile-time hide, as suggested in prior review threads.

## Files (9)

`MINIPC_HIDE_{AC,BATTERY,VBTN,R8168_ACPI}`, `SOC_INTEL_HIDE_EMMC`, EC ACPI `_STA` guards, Cannonlake `scs.asl`, `fsp_params.c`.

## Build / test plan

- [ ] `make defconfig CONFIG_DEFCONFIG=configs/cml/config.kaisa.uefi && make` (after #37, #38, edk2 #42)
- [ ] Flash DUT; Windows Device Manager: no `ACPI\R8168` Code 28; no eMMC host on NVMe SKU
- [ ] Verify wired Ethernet still enumerates and obtains DHCP
- [ ] Optional: compare `/sys/bus/acpi/devices/` on Linux   no `R8168:00`, no battery/AC nodes

## Dependencies

None. **#37** and **#38** depend on this PR.

## Out of scope

- Sleep profile (S0ix / S3 / XHCI wake)   deferred; see closed discussion in #39
- Type-C retimer (PS175) / RTD2142 ACPI visibility
- SATA (02D3) without disk   still enumerated at PCI level
