### PR TITLE
minipc: hide absent ACPI/PCI devices on Chromebox (Kaisa)

### DIFF
--- a/configs/cml/config.kaisa.uefi
+++ b/configs/cml/config.kaisa.uefi
@@ -1,3 +1,4 @@
+# Kaisa / Acer CXI4 Chromebox: hide laptop-only ACPI/PCI devices
 CONFIG_VENDOR_GOOGLE=y
 CONFIG_IFD_BIN_PATH="3rdparty/blobs/mainboard/google/puff/puff/flashdescriptor.bin"
 CONFIG_ME_BIN_PATH="3rdparty/blobs/mainboard/google/puff/puff/me.bin"
@@ -8,3 +9,9 @@ CONFIG_EC_GOOGLE_CHROMEEC_FIRMWARE_FILE="3rdparty/blobs/mainboard/google/puff/pu
 CONFIG_HAVE_ME_BIN=y
 CONFIG_DO_NOT_TOUCH_DESCRIPTOR_REGION=y
 CONFIG_NO_GFX_INIT=y
+CONFIG_MINIPC_HIDE_AC=y
+CONFIG_MINIPC_HIDE_BATTERY=y
+CONFIG_MINIPC_HIDE_VBTN=y
+CONFIG_MINIPC_HIDE_R8168_ACPI=y
+CONFIG_SOC_INTEL_HIDE_EMMC=y
+CONFIG_SOC_INTEL_HIDE_SATA=y

--- a/src/drivers/net/r8168.c
+++ b/src/drivers/net/r8168.c
@@ -417,7 +417,7 @@ static void r8168_init(struct device *dev)
 		enable_aspm_l1_2(io_base);
 }
 
-#if CONFIG(HAVE_ACPI_TABLES)
+#if CONFIG(HAVE_ACPI_TABLES) && !CONFIG(MINIPC_HIDE_R8168_ACPI)
 #define R8168_ACPI_HID "R8168"
 static void r8168_net_fill_ssdt(const struct device *dev)
 {
@@ -479,7 +479,7 @@ static struct device_operations r8168_ops  = {
 	.set_resources    = pci_dev_set_resources,
 	.enable_resources = pci_dev_enable_resources,
 	.init             = r8168_init,
-#if CONFIG(HAVE_ACPI_TABLES)
+#if CONFIG(HAVE_ACPI_TABLES) && !CONFIG(MINIPC_HIDE_R8168_ACPI)
 	.acpi_name        = r8168_net_acpi_name,
 	.acpi_fill_ssdt   = r8168_net_fill_ssdt,
 #endif

--- a/src/ec/google/chromeec/Kconfig
+++ b/src/ec/google/chromeec/Kconfig
@@ -254,6 +254,32 @@ config EC_GOOGLE_CHROMEEC_NEEDS_BATTERY_WORKAROUND
 	  logic.
 	  If unsure, say N.
 
+config MINIPC_HIDE_AC
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide AC adapter (ACPI0003) on mini PC / Chromebox"
+	default n
+
+config MINIPC_HIDE_BATTERY
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide battery (PNP0C0A) on mini PC / Chromebox"
+	default n
+
+config MINIPC_HIDE_VBTN
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide Chromebook keyboard/vbtn (GOOG000A, INT33D6) on mini PC / Chromebox"
+	default n
+
+config MINIPC_HIDE_R8168_ACPI
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide RTL8168 ACPI companion device (ACPI\\R8168) on mini PC / Chromebox"
+	default n
+	help
+	  Do not generate the RTL8168 SSDT ACPI device (_HID R8168) for the
+	  Realtek PCI NIC. Windows has no inbox driver for ACPI\\R8168 and
+	  shows Code 28 in Device Manager; the PCI Realtek driver still works.
+	  Linux/ChromeOS may use this ACPI node for wake/power control; say N
+	  if NIC ACPI wake is required on those OSes.
+
 config EC_GOOGLE_CHROMEEC_LPC_GENERIC_MEMORY_RANGE
 	def_bool n
 	help

--- a/src/ec/google/chromeec/acpi/ac.asl
+++ b/src/ec/google/chromeec/acpi/ac.asl
@@ -2,6 +2,7 @@
 
 // Scope (EC0)
 
+#if !CONFIG(MINIPC_HIDE_AC)
 Device (AC)
 {
 	Name (_HID, "ACPI0003")
@@ -17,3 +18,4 @@ Device (AC)
 		Return (0x0F)
 	}
 }
+#endif

--- a/src/ec/google/chromeec/acpi/battery.asl
+++ b/src/ec/google/chromeec/acpi/battery.asl
@@ -322,11 +322,15 @@ Method (BBST, 4, Serialized)
 	If (Local1 != DeRefOf (Arg2)) {
 		Arg2 = Local1
 		If (Arg0 == 0) {
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 			Notify (BAT0, 0x80)
+#endif
 		}
 #ifdef EC_ENABLE_SECOND_BATTERY_DEVICE
 		Else {
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 			Notify (BAT1, 0x80)
+#endif
 		}
 #endif
 	}
@@ -365,6 +369,7 @@ Method (BBST, 4, Serialized)
 	Return (Arg1)
 }
 
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 Device (BAT0)
 {
 	Name (_HID, EISAID ("PNP0C0A"))
@@ -454,8 +459,10 @@ Device (BAT0)
 		Return (BBST (0, PBST, RefOf (BSTP), BFWK))
 	}
 }
+#endif /* !CONFIG(MINIPC_HIDE_BATTERY) */
 
 #ifdef EC_ENABLE_SECOND_BATTERY_DEVICE
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 Device (BAT1)
 {
 	Name (_HID, EISAID ("PNP0C0A"))
@@ -545,4 +552,5 @@ Device (BAT1)
 		Return (BBST (1, PBST, RefOf (BSTP), BFWK))
 	}
 }
+#endif /* !CONFIG(MINIPC_HIDE_BATTERY) */
 #endif

--- a/src/ec/google/chromeec/acpi/ec.asl
+++ b/src/ec/google/chromeec/acpi/ec.asl
@@ -294,7 +294,9 @@ Device (EC0)
 	{
 		Printf ("EC: AC CONNECTED")
 		\PWRS = ACEX
+#if !CONFIG(MINIPC_HIDE_AC)
 		Notify (AC, 0x80)
+#endif
 #ifdef DPTF_ENABLE_CHARGER
 		If (CondRefOf (\_SB.DPTF.TCHG)) {
 			Notify (\_SB.DPTF.TCHG, 0x80)
@@ -314,7 +316,9 @@ Device (EC0)
 	{
 		Printf ("EC: AC DISCONNECTED")
 		\PWRS = ACEX
+#if !CONFIG(MINIPC_HIDE_AC)
 		Notify (AC, 0x80)
+#endif
 #ifdef DPTF_ENABLE_CHARGER
 		If (CondRefOf (\_SB.DPTF.TCHG)) {
 			Notify (\_SB.DPTF.TCHG, 0x80)
@@ -333,25 +337,31 @@ Device (EC0)
 	Method (_Q06, 0, NotSerialized)
 	{
 		Printf ("EC: BATTERY LOW")
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 		Notify (BAT0, 0x80)
+#endif
 	}
 
 	// Battery Critical Event
 	Method (_Q07, 0, NotSerialized)
 	{
 		Printf ("EC: BATTERY CRITICAL")
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 		Notify (BAT0, 0x80)
+#endif
 	}
 
 	// Battery Info Event
 	Method (_Q08, 0, NotSerialized)
 	{
 		Printf ("EC: BATTERY INFO")
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 		Notify (BAT0, 0x81)
+#endif
 #ifdef EC_ENABLE_SECOND_BATTERY_DEVICE
-		If (CondRefOf (BAT1)) {
-			Notify (BAT1, 0x81)
-		}
+#if !CONFIG(MINIPC_HIDE_BATTERY)
+		Notify (BAT1, 0x81)
+#endif
 #endif
 	}
 
@@ -387,7 +397,9 @@ Device (EC0)
 	Method (_Q11, 0, NotSerialized)
 	{
 		Printf ("EC: BATTERY SHUTDOWN")
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 		Notify (BAT0, 0x80)
+#endif
 	}
 
 	// Throttle Start
@@ -424,11 +436,13 @@ Device (EC0)
 	Method (_Q17, 0, NotSerialized)
 	{
 		Printf ("EC: BATTERY STATUS")
+#if !CONFIG(MINIPC_HIDE_BATTERY)
 		Notify (BAT0, 0x80)
+#endif
 #ifdef EC_ENABLE_SECOND_BATTERY_DEVICE
-		If (CondRefOf (BAT1)) {
-			Notify (BAT1, 0x80)
-		}
+#if !CONFIG(MINIPC_HIDE_BATTERY)
+		Notify (BAT1, 0x80)
+#endif
 #endif
 
 		/*

--- a/src/ec/google/chromeec/acpi/superio.asl
+++ b/src/ec/google/chromeec/acpi/superio.asl
@@ -95,7 +95,11 @@ Scope (\_SB.PCI0)
 		Name (_CID, Package() { EISAID("PNP0303"), EISAID("PNP030B") } )
 
 		Method (_STA, 0, NotSerialized) {
+#if CONFIG(MINIPC_HIDE_VBTN)
+			Return (0)
+#else
 			Return (0x0F)
+#endif
 		}
 
 		Name (_CRS, ResourceTemplate()

--- a/src/ec/google/chromeec/acpi/vbtn.asl
+++ b/src/ec/google/chromeec/acpi/vbtn.asl
@@ -23,7 +23,11 @@ Device (VBTN)
 	}
 	Method(_STA, 0)
 	{
+#if CONFIG(MINIPC_HIDE_VBTN)
+		Return (0)
+#else
 		Return (0xF)
+#endif
 	}
 }
 
@@ -33,6 +37,10 @@ Device (VBTO)
 	Name (_CID, "PNP0C60")
 	Method (_STA, 0)
 	{
+#if CONFIG(MINIPC_HIDE_VBTN)
+		Return (0)
+#else
 		Return (0xF)
+#endif
 	}
 }

--- a/src/mainboard/google/puff/variants/kaisa/overridetree.cb
+++ b/src/mainboard/google/puff/variants/kaisa/overridetree.cb
@@ -437,6 +437,7 @@ chip soc/intel/cannonlake
 				device i2c 1a on end
 			end
 		end
+		device ref sata		off end
 		device ref emmc		on end
 		device ref pcie_rp7	on
 			# RTL8111H Ethernet NIC

--- a/src/soc/intel/cannonlake/Kconfig
+++ b/src/soc/intel/cannonlake/Kconfig
@@ -307,6 +307,26 @@ config MB_HAS_ACTIVE_HIGH_SD_PWR_ENABLE
 	  This will enable a workaround in ASL _PS3 and _PS0 methods to force
 	  SD_PWR_ENABLE to stay low in D3.
 
+config SOC_INTEL_HIDE_EMMC
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Hide eMMC controller from OS (show only SD/TF slot as SD host)"
+	default n
+	help
+	  On mini PC / Chromebox with only one physical SD/TF card slot, the PCH
+	  still exposes both eMMC and SDXC in ACPI; Windows shows two "SD host
+	  controller" devices. Select this to hide the eMMC device (_STA = 0) so
+	  only the real SD/TF slot (SDXC) appears. eMMC will not be usable as
+	  storage in the OS when enabled.
+
+config SOC_INTEL_HIDE_SATA
+	depends on SYSTEM_TYPE_MINIPC
+	bool "Disable SATA AHCI controller (8086:02d3) on mini PC / Chromebox"
+	default n
+	help
+	  Kaisa-class Chromeboxes have no SATA disk. Disable the PCH SATA
+	  controller in FSP and devicetree so lspci/Windows do not expose
+	  8086:02d3.
+
 config FSP_HEADER_PATH
 	default "3rdparty/fsp/CoffeeLakeFspBinPkg/Include/" if SOC_INTEL_COFFEELAKE || SOC_INTEL_WHISKEYLAKE
 	default "3rdparty/fsp/CometLakeFspBinPkg/CometLake1/Include/" if SOC_INTEL_COMETLAKE_1

--- a/src/soc/intel/cannonlake/acpi/scs.asl
+++ b/src/soc/intel/cannonlake/acpi/scs.asl
@@ -21,6 +21,13 @@ Scope (\_SB.PCI0) {
 		Name (TEMP, 0)
 		Name (DSUU, ToUUID("f6c13ea5-65cd-461f-ab7a-29f7e8d5bd61"))
 
+#if CONFIG(SOC_INTEL_HIDE_EMMC)
+		Method (_STA, 0, NotSerialized)
+		{
+			Return (0)
+		}
+#endif
+
 		OperationRegion(SCSR, PCI_Config, 0x00, 0x100)
 		Field(SCSR, WordAcc, NoLock, Preserve) {
 			VDID, 32,	/* PCI VID DID */

--- a/src/soc/intel/cannonlake/fsp_params.c
+++ b/src/soc/intel/cannonlake/fsp_params.c
@@ -359,7 +359,8 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	s_cfg->PchLockDownRtcMemoryLock = 0;
 
 	/* SATA */
-	s_cfg->SataEnable = is_devfn_enabled(PCH_DEVFN_SATA);
+	s_cfg->SataEnable = CONFIG(SOC_INTEL_HIDE_SATA) ? 0 :
+		is_devfn_enabled(PCH_DEVFN_SATA);
 	if (s_cfg->SataEnable) {
 		s_cfg->SataMode = config->SataMode;
 		s_cfg->SataPwrOptEnable = config->satapwroptimize;
@@ -602,7 +603,7 @@ void platform_fsp_silicon_init_params_cb(FSPS_UPD *supd)
 	};
 
 	/* eMMC and SD */
-	s_cfg->ScsEmmcEnabled = is_devfn_enabled(PCH_DEVFN_EMMC);
+	s_cfg->ScsEmmcEnabled = CONFIG(SOC_INTEL_HIDE_EMMC) ? 0 : is_devfn_enabled(PCH_DEVFN_EMMC);
 	if (s_cfg->ScsEmmcEnabled) {
 		s_cfg->ScsEmmcHs400Enabled = config->ScsEmmcHs400Enabled;
 		s_cfg->PchScsEmmcHs400DllDataValid = config->EmmcHs400DllNeed;


### PR DESCRIPTION
## Summary

Replaces closed #36 with a cleaner Chromebox/minipc hide stack based on `MrChromebox-2606`.

- **AC / battery**: compile-time omit `ACPI0003` / `PNP0C0A` when `MINIPC_HIDE_*` is set (not `_STA=0`); EC Notify paths guarded
- **RTL8168**: skip SSDT generation via `MINIPC_HIDE_R8168_ACPI` (Windows Code 28 on `ACPI\R8168`)
- **eMMC / SATA**: `SOC_INTEL_HIDE_EMMC` (`_STA=0` + FSP) and `SOC_INTEL_HIDE_SATA` (FSP + kaisa devicetree `sata off`)
- **VBTN / keyboard**: `_STA=0` via `MINIPC_HIDE_VBTN`
- **`config.kaisa.uefi`**: enables all options for Acer CXI4 Chromebox

Sleep profile, PXE, RTC/fan fixes, and PL1 tuning are intentionally **not** included — will follow in separate PRs.

## Test plan

- [ ] `make lint` / checkpatch on touched ASL/Kconfig
- [ ] Build `config.kaisa.uefi` on Kaisa
- [ ] Windows Device Manager: no fake AC/battery/VBTN, no `ACPI\R8168` Code 28, single SD host, no SATA in PCI
- [ ] Linux: `lspci` no `8086:02d3`; ACPI nodes absent as expected


Made with [Cursor](https://cursor.com)