### PR TITLE
mb/google/poppy/rammus: Correct USB ACPI topology

### DIFF
--- a/src/mainboard/google/poppy/variants/rammus/devicetree.cb
+++ b/src/mainboard/google/poppy/variants/rammus/devicetree.cb
@@ -206,7 +206,6 @@ chip soc/intel/skylake
 				[1] = USB2_PORT_LONG(OC3),	// Type-A Port
 				[2] = USB2_PORT_SHORT(OC_SKIP),	// Bluetooth
 				[4] = USB2_PORT_LONG(OC1),	// Type-C Port 2
-				[6] = USB2_PORT_SHORT(OC_SKIP),	// H1
 				[8] = USB2_PORT_SHORT(OC_SKIP),	// Camera
 			}"
 
@@ -222,11 +221,13 @@ chip soc/intel/skylake
 					chip drivers/usb/acpi
 						register "desc" = ""USB Type C Port 1""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(1, 1)"
 						device usb 2.0 on end
 					end
 					chip drivers/usb/acpi
 						register "desc" = ""USB Type A Port 1""
 						register "type" = "UPC_TYPE_A"
+						register "group" = "ACPI_PLD_GROUP(3, 1)"
 						device usb 2.1 on end
 					end
 					chip drivers/usb/acpi
@@ -238,12 +239,31 @@ chip soc/intel/skylake
 					chip drivers/usb/acpi
 						register "desc" = ""USB Type C Port 2""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(2, 1)"
 						device usb 2.4 on end
 					end
 					chip drivers/usb/acpi
 						register "desc" = ""Camera""
 						register "type" = "UPC_TYPE_INTERNAL"
 						device usb 2.8 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(1, 1)"
+						device usb 3.0 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						device usb 3.1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type A Port 1""
+						register "type" = "UPC_TYPE_USB3_A"
+						register "group" = "ACPI_PLD_GROUP(3, 1)"
+						device usb 3.2 on end
 					end
 				end
 			end


### PR DESCRIPTION
## Source basis

- The review of [coreboot change 30607](https://review.coreboot.org/c/coreboot/+/30607) records the schematic check that `USB2_7_N/P` between PCH port 7 and H1 is not stuffed.
- `USB2_PORT_SHORT` sets `.enable = 1`; the Skylake silicon-init path copies that value to FSP `PortUsb20Enable`. The unused H1 entry therefore describes a port that is not present in the assembled hardware.
- Rammus already enables `DRIVERS_USB_ACPI`, but its explicit ACPI children cover only the USB2 personalities. The three live SuperSpeed personalities are missing `_UPC` and `_PLD` generation.

## Change

- Stop enabling the unstuffed H1 USB2 path.
- Add ACPI children for `SS01`, `SS02`, and `SS03`.
- Give each physical Type-C or Type-A HS/SS pair the same PLD group.

This leaves eight assembled USB personalities: `HS01`, `HS02`, `HS03`, `HS05`, `HS09`, `SS01`, `SS02`, and `SS03`.

## Validation

- `git diff --check` passes.
- Source-only review: no build, firmware image, flash, or hardware test was performed.

This remains a draft until the firmware-generated ACPI and all physical ports are tested on Rammus hardware.