### PR TITLE
mb/google/poppy/atlas: Complete USB ACPI topology

### DIFF
--- a/src/mainboard/google/poppy/variants/atlas/devicetree.cb
+++ b/src/mainboard/google/poppy/variants/atlas/devicetree.cb
@@ -232,6 +232,7 @@ chip soc/intel/skylake
 					chip drivers/usb/acpi
 						register "desc" = ""USB Type C Port 1""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(1, 1)"
 						device usb 2.0 on end
 					end
 					chip drivers/usb/acpi
@@ -243,7 +244,20 @@ chip soc/intel/skylake
 					chip drivers/usb/acpi
 						register "desc" = ""USB Type C Port 2""
 						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(2, 1)"
 						device usb 2.4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(1, 1)"
+						device usb 3.0 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 2""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						device usb 3.1 on end
 					end
 				end
 			end


### PR DESCRIPTION
## Source basis

- Atlas enables five USB personalities in FSP: `HS01`, `HS03`, `HS05`, `SS01`, and `SS02`.
- The original USB ACPI change [30754](https://review.coreboot.org/c/coreboot/+/30754) only enabled the three USB2 children to expose the Bluetooth reset GPIO.
- That review explicitly asked why the USB3 devices were omitted and warned that the partial tree could be mistaken for a complete topology.
- Google Eve already describes the same Skylake Type-C pairs with `HS01/SS01` in PLD group `(1,1)` and `HS05/SS02` in group `(2,1)`.

## Change

- Enable ACPI children for the already enabled `SS01` and `SS02` personalities.
- Give both sides of each physical Type-C HS/SS pair the same PLD group.
- Leave the FSP port tables, Bluetooth child, and every disabled address unchanged.

The resulting ACPI child set exactly matches the five FSP-enabled personalities. Their XHCI addresses are 1, 3, 5, 13, and 14.

## Validation

- `git diff --check` passes.
- coreboot checkpatch reports 0 errors and 0 warnings over 28 changed lines.
- Source-only review: no build, firmware image, flash, or hardware test was performed.

This remains a draft until the generated ACPI and both Type-C ports are tested on Atlas hardware. Standards-based `_UPC/_PLD` completeness does not by itself claim that every operating system derives the intended companion or mux behavior.