### PR TITLE
mb/google/poppy/nami: Add complete USB ACPI topology

### DIFF
--- a/src/mainboard/google/poppy/variants/nami/devicetree.cb
+++ b/src/mainboard/google/poppy/variants/nami/devicetree.cb
@@ -230,6 +230,76 @@ chip soc/intel/skylake
 				[2] = USB3_PORT_DEFAULT(OC2),	// Type-A Port
 				[3] = USB3_PORT_DEFAULT(OC_SKIP), // Card reader
 			}"
+
+			chip drivers/usb/acpi
+				register "desc" = ""Root Hub""
+				register "type" = "UPC_TYPE_HUB"
+				device usb 0.0 on
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 0""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(1, 1)"
+						device usb 2.0 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						device usb 2.1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type A Port""
+						register "type" = "UPC_TYPE_A"
+						register "group" = "ACPI_PLD_GROUP(3, 1)"
+						device usb 2.2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""Card Reader""
+						register "type" = "UPC_TYPE_INTERNAL"
+						register "group" = "ACPI_PLD_GROUP(4, 1)"
+						device usb 2.3 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""WiFi""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device usb 2.4 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""Rear Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device usb 2.5 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""Front Camera""
+						register "type" = "UPC_TYPE_INTERNAL"
+						device usb 2.6 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 0""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(1, 1)"
+						device usb 3.0 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type C Port 1""
+						register "type" = "UPC_TYPE_C_USB2_SS_SWITCH"
+						register "group" = "ACPI_PLD_GROUP(2, 1)"
+						device usb 3.1 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""USB Type A Port""
+						register "type" = "UPC_TYPE_USB3_A"
+						register "group" = "ACPI_PLD_GROUP(3, 1)"
+						device usb 3.2 on end
+					end
+					chip drivers/usb/acpi
+						register "desc" = ""Card Reader""
+						register "type" = "UPC_TYPE_INTERNAL"
+						register "group" = "ACPI_PLD_GROUP(4, 1)"
+						device usb 3.3 on end
+					end
+				end
+			end
 		end
 		device ref south_xdci		on  end
 		device ref thermal		on  end

--- a/src/mainboard/google/poppy/variants/nami/mainboard.c
+++ b/src/mainboard/google/poppy/variants/nami/mainboard.c
@@ -304,6 +304,7 @@ void variant_devtree_update(void)
 	case SKU_3_PANTHEON:
 	case SKU_4_PANTHEON:
 		cfg->usb2_ports[5].enable = 0;
+		DEV_PTR(usb2_port6)->enabled = 0;
 		spi_fpmcu->enabled = 0;
 		break;
 	case SKU_0_BARD:
@@ -324,6 +325,7 @@ void variant_devtree_update(void)
 	case SKU_7_EKKO:
 		pl2_id = PL2_ID_BARD_EKKO;
 		cfg->usb2_ports[5].enable = 0;
+		DEV_PTR(usb2_port6)->enabled = 0;
 		cfg->usb2_ports[7].enable = 0;
 		cfg->usb2_ports[8].enable = 0;
 		cfg->usb2_ports[9].enable = 0;


### PR DESCRIPTION
## Source basis

- Nami configures seven USB2 and four USB3 ports in the FSP tables.
- The shared Skylake chipset tree predeclares the matching RHUB children but leaves every child disabled.
- Unlike other Poppy variants, Nami does not enable any per-port USB ACPI child, so its assembled ports receive no generated `_UPC` or `_PLD` metadata.
- The FSP table already identifies the physical pairs by port comment and over-current pin: two Type-C connectors, one Type-A connector, and an internal card reader.

## Change

- Enable USB ACPI children for the eleven ports configured by the common Nami FSP table.
- Assign connector types for Type-C, Type-A, card reader, WiFi, and cameras.
- Give the Type-C, Type-A, and card-reader HS/SS pairs shared PLD groups.
- When a SKU disables the rear-camera USB2 PHY, also disable the matching `HS06` ACPI metadata child.

The runtime synchronization applies to every existing branch that clears `usb2_ports[5].enable`, including Pantheon, Vayne, Sona, Syndra, Bard, and Ekko SKUs. It does not remove `HS06` from Nami SKUs that retain the rear camera.

## Validation

- `git diff --check` passes.
- coreboot checkpatch reports 0 errors and 0 warnings over 90 changed lines.
- Source-only review: no build, firmware image, flash, or hardware test was performed.

The common XHCI DSDT namespace remains unchanged. On SKUs with the rear camera disabled, the static `HS06` object still has `_ADR=6`, while this change prevents the SSDT generator from adding `_UPC/_PLD`; that behavior is called out for firmware and OS validation rather than hidden by this draft.